### PR TITLE
Forcing Conan Version 1.58.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-python@v2
       - name: get conan
         uses: turtlebrowser/get-conan@main
+        with:
+           version: 1.58.0
       - name: cache conan
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Forces the Conan Version 1.58.0 to be used when Github Actions are run. Fixing this #8 Issue